### PR TITLE
Fix the behavior of the subcommand 'upver up'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           git commit -am "[GitHub Actions] Build for mac"
           git push
 
-  upver:
+  tag:
     runs-on: ubuntu-latest
     needs: [musl, mac]
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,12 +46,15 @@ impl Semver for Version {
     fn up_major(self, n: u64) -> Self {
         Version {
             major: self.clone().major + n,
+            minor: 0,
+            patch: 0,
             ..self
         }
     }
     fn up_minor(self, n: u64) -> Self {
         Version {
             minor: self.clone().minor + n,
+            patch: 0,
             ..self
         }
     }


### PR DESCRIPTION
- When a major update is made, set the minor and patch to zero.
- When a minor update is made, set the patch to zero.

Example.
```
upver up -x Cargo.toml
```
1.2.3 -> 2.0.0
