### PR TITLE
Add options: upver show --core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Release
 
-on: [push]
-# on:
-#   pull_request:
-#     branches:
-#       - alpha
-#     types: [closed]
+on:
+  pull_request:
+    branches:
+      - alpha
+    types: [closed]
 
 jobs:
   upver:
@@ -50,7 +49,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -am "[GitHub Actions] Build for linux"
-          git push --force
+          git push
 
   mac:
     name: x86_64-apple-darwin
@@ -75,7 +74,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -am "[GitHub Actions] Build for mac"
-          git push --force
+          git push
 
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add options: `upver show --core`

Example.
If the version is x.y.z-alpha+beta, the standard output is x.y.z.
```
upver show --core Cargo.toml
```
